### PR TITLE
Fixing imports and providing functionality to on_finish function

### DIFF
--- a/src/EmotionRecognitionTask.ts
+++ b/src/EmotionRecognitionTask.ts
@@ -632,9 +632,16 @@ export default async function emotionRecognitionTask(onFinish?: (data: any) => v
     on_finish: function () {
       try {
         const filteredData = jsPsych.data.get().filter({ trialType: 'emotionChoice' });
-        const resultJson = transformAndExportJson(filteredData);
-        transformAndDownload(filteredData);
-        downloadJson(resultJson, resultJson.timestamp);
+        if(onFinish)
+        {
+          onFinish(transformAndExportJson(filteredData))
+        }
+        else {
+          const resultJson = transformAndExportJson(filteredData);
+          transformAndDownload(filteredData);
+          downloadJson(resultJson, resultJson.timestamp);
+        }
+        
       } catch (error) {
         console.error('Error collection Emotion Recognition Data:', error);
       }

--- a/src/EmotionRecognitionTask.ts
+++ b/src/EmotionRecognitionTask.ts
@@ -17,11 +17,11 @@ import { transformAndExportJson, downloadJson, transformAndDownload } from './da
 
 export default async function emotionRecognitionTask(onFinish?: (data: any) => void) {
   translator.init();
-  const { initJsPsych } = await import('/runtime/v1/jspsych@8.x');
+  const { initJsPsych } = await import('/runtime/v1/jspsych@8.x/index.js');
   type JsPsych = import('/runtime/v1/jspsych@8.x/index.js').JsPsych;
-  const { HtmlKeyboardResponsePlugin } = await import('/runtime/v1/@jspsych/plugin-html-keyboard-response@2.x');
-  const { HtmlButtonResponsePlugin } = await import('/runtime/v1/@jspsych/plugin-html-button-response@2.x');
-  const { PreloadPlugin } = await import('/runtime/v1/@jspsych/plugin-preload@2.x');
+  const { HtmlKeyboardResponsePlugin } = await import('/runtime/v1/@jspsych/plugin-html-keyboard-response@2.x/index.js');
+  const { HtmlButtonResponsePlugin } = await import('/runtime/v1/@jspsych/plugin-html-button-response@2.x/index.js');
+  const { PreloadPlugin } = await import('/runtime/v1/@jspsych/plugin-preload@2.x/index.js');
 
   type EmotionalTrialData = {
     correctResponse: string;

--- a/src/EmotionRecognitionTask.ts
+++ b/src/EmotionRecognitionTask.ts
@@ -13,9 +13,16 @@ import type { Language } from '@opendatacapture/runtime-v1/@opendatacapture/runt
 import { translator } from './translations.ts';
 import { experimentSettingsJson } from './experimentSettings.ts';
 import { $Settings } from './schemas.ts';
+import type { EmotionRecognitionTask } from './schemas.ts';
 import { transformAndExportJson, downloadJson, transformAndDownload } from './dataMunger.ts';
 
-export default async function emotionRecognitionTask(onFinish?: (data: any) => void) {
+type EmotionRecognitionTaskResult = {
+  version: string;
+  timestamp: string;
+  experimentResult: EmotionRecognitionTask[];
+};
+
+export default async function emotionRecognitionTask(onFinish?: (data: EmotionRecognitionTaskResult) => void) {
   translator.init();
   const { initJsPsych } = await import('/runtime/v1/jspsych@8.x/index.js');
   type JsPsych = import('/runtime/v1/jspsych@8.x/index.js').JsPsych;

--- a/src/EmotionRecognitionTask.ts
+++ b/src/EmotionRecognitionTask.ts
@@ -15,7 +15,7 @@ import { experimentSettingsJson } from './experimentSettings.ts';
 import { $Settings } from './schemas.ts';
 import { transformAndExportJson, downloadJson, transformAndDownload } from './dataMunger.ts';
 
-export default async function emotionRecognitionTask() {
+export default async function emotionRecognitionTask(onFinish?: (data: any) => void) {
   translator.init();
   const { initJsPsych } = await import('/runtime/v1/jspsych@8.x');
   type JsPsych = import('/runtime/v1/jspsych@8.x/index.js').JsPsych;

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,7 +21,7 @@ export default defineInstrument({
     name: 'Emotion Recognition Task'
   },
   content: {
-    render() {
+    async render(done) {
       const settingsParseResult = $Settings.safeParse(experimentSettingsJson);
 
       // parse settings
@@ -30,7 +30,7 @@ export default defineInstrument({
       }
       // translator.init();
       translator.changeLanguage(settingsParseResult.data.language as Language);
-      emotionRecognitionTask();
+      emotionRecognitionTask(done);
     }
   },
   details: {
@@ -43,6 +43,8 @@ export default defineInstrument({
   measures: {},
 
   validationSchema: z.object({
-    message: $EmotionRecognitionTaskResult
+    version: z.string(),
+    timestamp: z.string(),
+    experimentResult: z.array($EmotionRecognitionTaskResult)
   })
 });

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -16,7 +16,7 @@ const $LoggingTrial = $Trial.extend({
   difficultyLevel: z.coerce.number().positive().int().optional(),
   language: $Language.optional(),
   response: z.string(),
-  rt: z.coerce.number().positive().int()
+  rt: z.coerce.number().positive()
 });
 export const $ExperimentResults = $LoggingTrial.omit({ response: true, trialType: true }).extend({
   responseNotes: z.string(),


### PR DESCRIPTION
works on issue #7 

trial data now gets passed to ODC instance
allows for float for response time
fixed imports for jspsych runtime uses

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced emotion recognition processing with flexible result handling options.
	- Improved component rendering that now operates asynchronously, leading to smoother task completion.
	- Expanded data validation to capture detailed experiment information, including version, timestamp, and results.
	- Updated performance tracking allows for more flexible measurement of response values.
- **Bug Fixes**
	- Adjusted response time property to accept a broader range of positive numbers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->