### PR TITLE
Consistent variable name and other odc fixes

### DIFF
--- a/src/dataMunger.ts
+++ b/src/dataMunger.ts
@@ -66,7 +66,7 @@ function exportToJsonSerializable(data: EmotionRecognitionTask[]): {
   return {
     version: '1.0',
     timestamp: getLocalTime(),
-    experimentResults: data.map((result) => ({
+    experimentResult: data.map((result) => ({
       correctResponse: result.correctResponse,
       correctResponseSelected: result.correctResponseSelected,
       response: result.response,

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,8 +28,7 @@ export default defineInstrument({
       if (!settingsParseResult.success) {
         throw new Error(`Validation error, check experiment settings: ${settingsParseResult.error.toString()}`)
       }
-      // translator.init();
-      translator.changeLanguage(settingsParseResult.data.language as Language);
+      translator.init();
       emotionRecognitionTask(done);
     }
   },


### PR DESCRIPTION
works on issue #7 

Fixes issue of ODC 422 error of undefined experimentResults section, Now the variable is known as experimentResult in all 3 files (index.ts, dataMunger.ts, EmotionRecognitionTask.ts)

Made language set by ODC Language by default instead of settings.ts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated the structure of exported data by adopting a singular key for grouping experiment outcomes, enhancing clarity and consistency in data presentation.
  - Revised the language translation setup by streamlining the initialization process. These changes further ensure that language handling is smoother and more consistent throughout the entire application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->