### PR TITLE
Replace alert with text warning, make ODC wrapper billingual

### DIFF
--- a/src/EmotionRecognitionTask.ts
+++ b/src/EmotionRecognitionTask.ts
@@ -5,6 +5,7 @@ import {
   audioHtmlGenerator,
   createContinueButtonDiv,
   createExamplePromptDiv,
+  createWarningText,
   revealEmotionButtons,
   videoCoverHtmlGenerator
 } from './helperFunctions.ts';
@@ -217,16 +218,19 @@ export default async function emotionRecognitionTask(onFinish?: (data: EmotionRe
 
         const continueButton = addContinueButton();
         const continueButtonDiv = createContinueButtonDiv(continueButton);
+        const warningText = createWarningText(translator.t('buttonSelectionWarning'))
         const examplePrompt = createExamplePromptDiv(translator.t('examplePrompt'));
         const jsPsychContent = document.getElementById('jspsych-content');
 
         if (jsPsychContent && jsPsychContent instanceof HTMLElement) {
           jsPsychContent.appendChild(continueButtonDiv);
+          jsPsychContent.appendChild(warningText);
           if(isExample){
             jsPsychContent.appendChild(examplePrompt);
           } 
         } else {
           document.body.appendChild(continueButtonDiv);
+          document.body.appendChild(warningText);
           if(isExample){
             document.body.appendChild(examplePrompt);
           } 
@@ -280,7 +284,7 @@ export default async function emotionRecognitionTask(onFinish?: (data: EmotionRe
         });
         continueButton.addEventListener('click', () => {
           if (!finalResponse) {
-            alert(translator.t('buttonSelectionWarning'));
+            warningText.style.display = 'flex'
             return;
           }
           jsPsych.finishTrial({
@@ -465,16 +469,19 @@ export default async function emotionRecognitionTask(onFinish?: (data: EmotionRe
 
         const examplePrompt = createExamplePromptDiv(translator.t('examplePrompt'));
         const continueButton = addContinueButton();
+        const warningText = createWarningText(translator.t('buttonSelectionWarning'))
         const continueButtonDiv = createContinueButtonDiv(continueButton);
         const jsPsychContent = document.getElementById('jspsych-content');
 
         if (jsPsychContent && jsPsychContent instanceof HTMLElement) {
           jsPsychContent.appendChild(continueButtonDiv);
+          jsPsychContent.appendChild(warningText);
           if(isExample){
             jsPsychContent.appendChild(examplePrompt);
           } 
         } else {
           document.body.appendChild(continueButtonDiv);
+          document.body.appendChild(warningText);
           if(isExample){
             document.body.appendChild(examplePrompt);
           } 
@@ -548,7 +555,7 @@ export default async function emotionRecognitionTask(onFinish?: (data: EmotionRe
 
         continueButton.addEventListener('click', () => {
           if (!finalResponse) {
-            alert(translator.t('buttonSelectionWarning'));
+            warningText.style.display = 'flex';
             return;
           }
           jsPsych.finishTrial({

--- a/src/helperFunctions.ts
+++ b/src/helperFunctions.ts
@@ -34,6 +34,18 @@ export const createContinueButtonDiv = (continueButton: HTMLButtonElement) => {
   return continueButtonDiv;
 };
 
+export const createWarningText = (text: string) => {
+  const textBox = document.createElement('p') as HTMLParagraphElement
+  textBox.style.justifyContent = 'center';
+  textBox.style.alignItems = 'center';
+  textBox.style.display = 'None';
+  textBox.style.paddingTop = '1%';
+  textBox.style.color = 'red'
+  textBox.textContent = text
+
+  return textBox
+}
+
 export const createExamplePromptDiv = (content: string) => {
   const exampleDiv = document.createElement('div');
   exampleDiv.style.justifyContent = 'center';

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,13 +7,13 @@ const { z } = await import('/runtime/v1/zod@3.23.x/index.js');
 import { $EmotionRecognitionTaskResult, $Settings } from './schemas.ts';
 import { translator } from './translations.ts';
 
-import type { Language } from "/runtime/v1/@opendatacapture/runtime-core";
-
 export default defineInstrument({
   kind: "INTERACTIVE",
-    // if multilingual experimentSettingsJson needs a language field
-  language: experimentSettingsJson.language as Language,
-  tags: ["interactive", "jsPysch", "EmotionRecognitionTask"],
+  language: ['en', 'fr'],
+  tags: {
+    en: ["interactive", "jsPysch", "EmotionRecognitionTask"],
+    fr: ["interactif", "jsPysch", "EmotionRecognitionTask"]
+  },
 
 
   internal: {
@@ -33,11 +33,20 @@ export default defineInstrument({
     }
   },
   details: {
-    description: 'A task to decipher a subjects ability to interpret emotion displayed in audio and visual mediums',
+    description: {
+      en: 'A task to decipher a subjects ability to interpret emotion displayed in audio and visual mediums',
+      fr: "Une tâche visant à déchiffrer la capacité d'un sujet à interpréter les émotions affichées dans des supports audio et visuels"
+    } ,
     estimatedDuration: 20,
-    instructions: ['Please read the instruction presented within the task carefully'],
+    instructions: {
+      en: ['Please read the instruction presented within the task carefully'],
+      fr: ['Veuillez lire attentivement les instructions présentées dans la tâche']
+    },
     license: 'UNLICENSED',
-    title: 'Emotion Recognition Task'
+    title: {
+      en: 'Emotion Recognition Task',
+      fr: 'Tâche de reconnaissance des émotions'
+    }
   },
   measures: {},
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,7 +13,7 @@ export default defineInstrument({
   kind: "INTERACTIVE",
     // if multilingual experimentSettingsJson needs a language field
   language: experimentSettingsJson.language as Language,
-  tags: ["interactive", "jsPysch", "PictureNamingTask"],
+  tags: ["interactive", "jsPysch", "EmotionRecognitionTask"],
 
 
   internal: {

--- a/src/translations.ts
+++ b/src/translations.ts
@@ -81,8 +81,8 @@ export const translator = new Translator({
           Un exemple vous sera présenté avant de débuter le test.`
     },
     buttonSelectionWarning: {
-      en: `Please select a button`,
-      fr: `Veuillez sélectionner un bouton`
+      en: `* Please select a button`,
+      fr: `* Veuillez sélectionner un bouton`
     },
     examplePrompt: {
       en: `Click on continue to start the test`,


### PR DESCRIPTION
close issue #33 and #34 

no more alerts!

index.ts  now uses billingual format instead

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced inline warning messages when no button selection is made before continuing in emotion recognition tasks, replacing blocking alert dialogs.
- **Enhancements**
  - Improved bilingual support by updating instrument details, instructions, and tags to include both English and French.
  - Updated warning messages to be more visually distinct with a leading asterisk.
- **User Interface**
  - Warning messages now appear inline and styled in red for better visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->