### PR TITLE
chore: add .npmrc for supply-chain hardening

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,7 @@
+# Quarantine newly-published packages for 7 days (10080 minutes).
+# Most malicious versions are caught and unpublished well within this window.
+minimum-release-age=10080
+
+# Block transitive deps from using non-registry specifiers (git:, github:, tarball URLs).
+# This was the exact injection vector in the @tanstack/router* attack (TanStack/router#7383).
+block-exotic-subdeps=true


### PR DESCRIPTION
## Summary

Adds an `.npmrc` with two pnpm supply-chain hardening settings:

- `minimum-release-age=10080` — quarantine newly-published package versions for 7 days (10080 min). Most malicious versions are unpublished well within that window. Requires pnpm 10+.
- `block-exotic-subdeps=true` — block transitive deps from using non-registry specifiers (git:/github:/tarball URLs). Mitigates the `@tanstack/router*` injection vector (TanStack/router#7383).

This repo is on `pnpm@10.10.0` so both settings are active immediately. No lockfile change needed.

## Test plan

- [ ] `pnpm install` still works
- [ ] CI passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated npm configuration to enforce stricter package and dependency requirements.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DouglasNeuroInformatics/EmotionRecognitionTask/pull/50)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->